### PR TITLE
fix : compare password

### DIFF
--- a/src/app/kng-user/user-password.component.ts
+++ b/src/app/kng-user/user-password.component.ts
@@ -47,9 +47,10 @@ export class UserPasswordComponent {
       'password':   ['',[Validators.required,Validators.minLength(6)]],
       'confirm':  ['', [Validators.required,Validators.minLength(6)]]
     },{
-      Validators:KngInputValidator.MatchPasswordAndConfirm
+      validator:KngInputValidator.MatchPasswordAndConfirm
     });
     //[ngModelOptions]="{updateOn: 'blur'}"
+
   }
 
   get locale(){


### PR DESCRIPTION
tester la comparaison de mot de passe.
Reste à faire que le mot de passe soit correct pour modifier les donnés dans account, d'ailleurs je constate à l'instant que le mdp vient par défaut, ne faudrait-il pas que le champs soit vide?
2 comportements différent sur mon localhost et en dev, peut-être est-ce parce que sur localhost j'ai enregistré mon mdp?
Quel serait le fonctionnement idéal?